### PR TITLE
added support of Parameters passing to getConnection

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0
+current_version = 0.2.1
 commit = True
 tag = True
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .ropeproject/globalnames
 .ropeproject/history
 .ropeproject/objectdb
+.idea
 *.bak
 *~
 mem.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
     - TESTNAME=test_mock JDBC_DRIVER=org.jaydebeapi:mockdriver:1.0-SNAPSHOT
     - TESTNAME=test_integration.HsqldbTest JDBC_DRIVER=org.hsqldb:hsqldb:1.8.0.10
     - TESTNAME=test_integration.SqliteXerialTest JDBC_DRIVER=org.xerial:sqlite-jdbc:3.7.2
+    - TESTNAME=test_integration.HsqldbDictParamsTest JDBC_DRIVER=org.hsqldb:hsqldb:1.8.0.10
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ python:
   - '3.4'
 
 env:
-  - JYTHON=true
-  - JYTHON=false
   matrix:
     - TESTNAME=test_mock JDBC_DRIVER=org.jaydebeapi:mockdriver:1.0-SNAPSHOT
     - TESTNAME=test_integration.HsqldbTest JDBC_DRIVER=org.hsqldb:hsqldb:1.8.0.10
@@ -37,9 +35,6 @@ matrix:
       env: JYTHON=org.python:jython-installer:2.7-rc1 TESTNAME=test_integration.HsqldbDictParamsTest JDBC_DRIVER=org.hsqldb:hsqldb:1.8.0.10
     - python: 2.7
       env: JYTHON=org.python:jython-installer:2.7-rc1 TESTNAME=test_mock JDBC_DRIVER=org.jaydebeapi:mockdriver:1.0-SNAPSHOT
-  exclude:
-    - python: 2.6
-      env: JYTHON=true
 
 before_install:
   - ci/before_install.sh
@@ -50,8 +45,6 @@ install:
   - source $HOME/myvirtualenv/bin/activate
   - pip install -e .
   - if [ -z "$JYTHON" ]; then pip install coveralls ;fi
-
-before_script: if [ "$JYTHON" == "true" ]; then export PYTHON_EXE=jython; jython -c "print ''"; else export PYTHON_EXE=python; fi
 
 script:
   - if [ -z "$JYTHON" ]; then PY="coverage run --source jaydebeapi"; else PY="python" ;fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ deploy:
 
 python:
   - '2.6'
-  - '2.7'
-  - '3.4'
+  #- '2.7'
+  #- '3.4'
 
 env:
   matrix:
@@ -44,12 +44,14 @@ install:
   - if [ -n "$JDBC_DRIVER" ]; then envsubst < ci/dot_jip > $VIRTUAL_ENV/.jip && pip install jip==0.9.3 && jip install $JDBC_DRIVER && export CLASSPATH=$VIRTUAL_ENV/javalib/* ;fi # TODO: Fix jip to search for local maven repo without twaking .jip
   - source $HOME/myvirtualenv/bin/activate
   - pip install -e .
-  - if [ -z "$JYTHON" ]; then pip install coveralls ;fi
+  #- if [ -z "$JYTHON" ]; then pip install coveralls ;fi
+  - pip install coveralls
 
 script:
   - if [ -z "$JYTHON" ]; then PY="coverage run --source jaydebeapi"; else PY="$HOME/jython/bin/jython "$VIRTUAL_ENV"/bin/coverage run --source jaydebeapi" ;fi
   - $PY test/testsuite.py $TESTNAME
 
 after_success:
-  - if [ -z "$JYTHON" ]; then coveralls ;fi
+  #- if [ -z "$JYTHON" ]; then coveralls ;fi
+  - coveralls
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,3 +52,4 @@ script:
 
 after_success:
   - if [ -z "$JYTHON" ]; then coveralls ;fi
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
   - if [ -z "$JYTHON" ]; then pip install coveralls ;fi
 
 script:
-  - if [ -z "$JYTHON" ]; then PY="coverage run --source jaydebeapi"; else PY="python" ;fi
+  - if [ -z "$JYTHON" ]; then PY="coverage run --source jaydebeapi"; else PY="$HOME/jython/bin/jython "$VIRTUAL_ENV"/bin/coverage run --source jaydebeapi" ;fi
   - $PY test/testsuite.py $TESTNAME
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ deploy:
 
 python:
   - '2.6'
-  #- '2.7'
-  #- '3.4'
+  - '2.7'
+  - '3.4'
 
 env:
   matrix:
@@ -24,7 +24,6 @@ env:
     - TESTNAME=test_integration.HsqldbTest JDBC_DRIVER=org.hsqldb:hsqldb:1.8.0.10
     - TESTNAME=test_integration.SqliteXerialTest JDBC_DRIVER=org.xerial:sqlite-jdbc:3.7.2
     - TESTNAME=test_integration.HsqldbDictParamsTest JDBC_DRIVER=org.hsqldb:hsqldb:1.8.0.10
-
 matrix:
   include:
     - python: 2.7
@@ -32,9 +31,9 @@ matrix:
     - python: 2.7
       env: JYTHON=org.python:jython-installer:2.7-rc1 TESTNAME=test_integration.HsqldbTest JDBC_DRIVER=org.hsqldb:hsqldb:1.8.0.10
     - python: 2.7
-      env: JYTHON=org.python:jython-installer:2.7-rc1 TESTNAME=test_integration.HsqldbDictParamsTest JDBC_DRIVER=org.hsqldb:hsqldb:1.8.0.10
-    - python: 2.7
       env: JYTHON=org.python:jython-installer:2.7-rc1 TESTNAME=test_mock JDBC_DRIVER=org.jaydebeapi:mockdriver:1.0-SNAPSHOT
+    - python: 2.7
+      env: JYTHON=org.python:jython-installer:2.7-rc1 TESTNAME=test_integration.HsqldbDictParamsTest JDBC_DRIVER=org.hsqldb:hsqldb:1.8.0.10
 
 before_install:
   - ci/before_install.sh
@@ -43,15 +42,16 @@ install:
   - if [ "$JDBC_DRIVER" == "org.jaydebeapi:mockdriver:1.0-SNAPSHOT" ]; then (cd mockdriver && mvn install) ;fi
   - if [ -n "$JDBC_DRIVER" ]; then envsubst < ci/dot_jip > $VIRTUAL_ENV/.jip && pip install jip==0.9.3 && jip install $JDBC_DRIVER && export CLASSPATH=$VIRTUAL_ENV/javalib/* ;fi # TODO: Fix jip to search for local maven repo without twaking .jip
   - source $HOME/myvirtualenv/bin/activate
-  - pip install -e .
-  #- if [ -z "$JYTHON" ]; then pip install coveralls ;fi
+  - if [ $JYTHON ]; then $HOME/jython/bin/pip install -e . ; else pip install -e . ; fi
+  - if [ "$JYTHON" ]; then $HOME/jython/bin/pip install coverage==3.7.1 ;fi
   - pip install coveralls
 
+
 script:
-  - if [ -z "$JYTHON" ]; then PY="coverage run --source jaydebeapi"; else PY="$HOME/jython/bin/jython "$VIRTUAL_ENV"/bin/coverage run --source jaydebeapi" ;fi
+  - if [ -z "$JYTHON" ]; then PY="coverage run --source jaydebeapi"; else PY="$HOME/jython/bin/jython $HOME/jython/bin/coverage run --source jaydebeapi" ;fi
   - $PY test/testsuite.py $TESTNAME
 
 after_success:
-  #- if [ -z "$JYTHON" ]; then coveralls ;fi
+  - if [ "$JYTHON" ]; then ci/convert_coverage.py ;fi
   - coveralls
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ python:
   - '3.4'
 
 env:
+  - JYTHON=true
+  - JYTHON=false
   matrix:
     - TESTNAME=test_mock JDBC_DRIVER=org.jaydebeapi:mockdriver:1.0-SNAPSHOT
     - TESTNAME=test_integration.HsqldbTest JDBC_DRIVER=org.hsqldb:hsqldb:1.8.0.10
@@ -32,7 +34,12 @@ matrix:
     - python: 2.7
       env: JYTHON=org.python:jython-installer:2.7-rc1 TESTNAME=test_integration.HsqldbTest JDBC_DRIVER=org.hsqldb:hsqldb:1.8.0.10
     - python: 2.7
+      env: JYTHON=org.python:jython-installer:2.7-rc1 TESTNAME=test_integration.HsqldbDictParamsTest JDBC_DRIVER=org.hsqldb:hsqldb:1.8.0.10
+    - python: 2.7
       env: JYTHON=org.python:jython-installer:2.7-rc1 TESTNAME=test_mock JDBC_DRIVER=org.jaydebeapi:mockdriver:1.0-SNAPSHOT
+  exclude:
+    - python: 2.6
+      env: JYTHON=true
 
 before_install:
   - ci/before_install.sh
@@ -43,6 +50,8 @@ install:
   - source $HOME/myvirtualenv/bin/activate
   - pip install -e .
   - if [ -z "$JYTHON" ]; then pip install coveralls ;fi
+
+before_script: if [ "$JYTHON" == "true" ]; then export PYTHON_EXE=jython; jython -c "print ''"; else export PYTHON_EXE=python; fi
 
 script:
   - if [ -z "$JYTHON" ]; then PY="coverage run --source jaydebeapi"; else PY="python" ;fi

--- a/README.rst
+++ b/README.rst
@@ -166,6 +166,7 @@ Changelog
 =========
 
 - Next version - unreleased
+- 0.2.1 - 2016-10-16
   - `Connection with properties <https://docs.oracle.com/javase/7/docs/api/java/sql/DriverManager.html#getConnection(java.lang.String,%20java.util.Properties)>`_ support.
 - 0.2.0 - 2015-04-26
 

--- a/README.rst
+++ b/README.rst
@@ -166,6 +166,7 @@ Changelog
 =========
 
 - Next version - unreleased
+  - `Connection with properties <https://docs.oracle.com/javase/7/docs/api/java/sql/DriverManager.html#getConnection(java.lang.String,%20java.util.Properties)>`_ support.
 - 0.2.0 - 2015-04-26
 
   - Python 3 support (requires JPype1 >= 0.6.0).

--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,28 @@ Here is an example:
 >>> curs.fetchall()
 [(1, u'John')]
 
+Also it's possible to make connections with additional attributes.
+For example, you can specify there your domain name.
+You can read about this in `java docs <https://docs.oracle.com/javase/7/docs/api/java/sql/DriverManager.html#getConnection(java.lang.String,%20java.util.Properties>`_
+
+>>> import jaydebeapi
+>>> connection_props = {'user':'SA', 'password':''}
+>>> conn = jaydebeapi.connect('org.hsqldb.jdbcDriver',
+...                           ('jdbc:hsqldb:mem:.', connection_props),
+...                           '/path/to/hsqldb.jar',)
+>>> curs = conn.cursor()
+>>> curs.execute('create table CUSTOMER'
+...                '("CUST_ID" INTEGER not null,'
+...                ' "NAME" VARCHAR not null,'
+...                ' primary key ("CUST_ID"))'
+...             )
+>>> curs.execute("insert into CUSTOMER values (1, 'John')")
+>>> curs.execute("select * from CUSTOMER")
+>>> curs.fetchall()
+[(1, u'John')]
+
+
+
 If you're having trouble getting this work check if your ``JAVA_HOME``
 environmentvariable is set correctly. For example I have to set it on
 my Ubuntu machine like this ::

--- a/README.rst
+++ b/README.rst
@@ -100,25 +100,36 @@ Here is an example:
 >>> curs.fetchall()
 [(1, u'John')]
 
-Also it's possible to make connections with additional attributes.
-For example, you can specify there your domain name.
-You can read about this in `java docs <https://docs.oracle.com/javase/7/docs/api/java/sql/DriverManager.html#getConnection(java.lang.String,%20java.util.Properties>`_
+Also it's possible to make connections using attributes dict.
+It allows to pass additional parameters to connection in more comfort way than in connection string.
+ Also it helps with parameters which cannot be passed via url, for example ``accessToken`` for MS SQL server
+ (see `documentation <https://msdn.microsoft.com/en-us/library/ms378988(v=sql.110).aspx>`_).
+You can read more about this in `java docs <https://docs.oracle.com/javase/7/docs/api/java/sql/DriverManager.html#getConnection(java.lang.String,%20java.util.Properties>`_
+
+Here's an example of connecting to MS SQL Server with Windows domain credentials:
 
 >>> import jaydebeapi
->>> connection_props = {'user':'SA', 'password':''}
->>> conn = jaydebeapi.connect('org.hsqldb.jdbcDriver',
-...                           ('jdbc:hsqldb:mem:.', connection_props),
-...                           '/path/to/hsqldb.jar',)
+>>> connection_parameters = {
+...    "user": "DomainUserName",
+...    "password": "DomainPassW0RD!",
+...    "domain": "DOMAINNAME"
+... }
+>>> conn = jaydebeapi.connect('net.sourceforge.jtds.jdbc.Driver',
+...                           ('jdbc:jtds:sqlserver://server:1433/database', connection_parameters),
+...                           '/path/to/jar/jtds-1.2.5.jar',)
+>>> conn.setAutoCommit(False)
 >>> curs = conn.cursor()
->>> curs.execute('create table CUSTOMER'
-...                '("CUST_ID" INTEGER not null,'
-...                ' "NAME" VARCHAR not null,'
-...                ' primary key ("CUST_ID"))'
-...             )
->>> curs.execute("insert into CUSTOMER values (1, 'John')")
->>> curs.execute("select * from CUSTOMER")
+>>> curs.execute('CREATE TABLE Users ('
+...             'id INT PRIMARY KEY NOT NULL AUTO_INCREMENT, '
+...             'Name VARCHAR(200), '
+...             'Location VARCHAR(200) '
+...             ');')
+>>> curs.execute("insert into Users (Name, Location) values ('John', 'North Pole')")
+>>> conn.commit()
+>>>
+>>> curs.execute("select * from Users")
 >>> curs.fetchall()
-[(1, u'John')]
+[(1, u'John', u'North Pole')]
 
 
 

--- a/README_development.rst
+++ b/README_development.rst
@@ -12,7 +12,7 @@ Running tests
 
      sudo apt-get install maven
      cd mockdriver
-     maven install
+     mvn install
 
      virtualenv ~/.virtualenvs/jaydebeapi-py26 -p /usr/bin/python2.6
      . ~/.virtualenvs/jaydebeapi-py26/bin/activate

--- a/README_development.rst
+++ b/README_development.rst
@@ -14,9 +14,10 @@ Running tests
      cd mockdriver
      mvn install
 
-     virtualenv ~/.virtualenvs/jaydebeapi-py26 -p /usr/bin/python2.6
-     . ~/.virtualenvs/jaydebeapi-py26/bin/activate
-     pip install -r dev-requirements.txt -r requirements-python.txt -r test-requirements.txt jip==0.9.3
+     cd ..
+     virtualenv ~/.virtualenvs/jaydebeapi-py27 -p /usr/bin/python2.7
+     . ~/.virtualenvs/jaydebeapi-py27/bin/activate
+     pip install -r dev-requirements.txt -r requirements-python-2.7.txt -r jip==0.9.3
      envsubst < ci/dot_jip > $VIRTUAL_ENV/.jip
      jip install org.jaydebeapi:mockdriver:1.0-SNAPSHOT
      jip install org.hsqldb:hsqldb:1.8.0.10

--- a/README_development.rst
+++ b/README_development.rst
@@ -6,9 +6,10 @@ Some notes for development.
 
 .. contents::
 
-Setup test requirements
+Running tests
 =======================
-::
+1. Setup requirements. ::
+
      sudo apt-get install maven
      cd mockdriver
      maven install
@@ -22,6 +23,9 @@ Setup test requirements
      jip install org.xerial:sqlite-jdbc:3.7.2
      export CLASSPATH=$VIRTUAL_ENV/javalib/*
      python setup.py develop
+
+2. Running tests. ::
+
      python test/testsuite.py
 
 Build a new release

--- a/README_development.rst
+++ b/README_development.rst
@@ -8,21 +8,21 @@ Some notes for development.
 
 Setup test requirements
 =======================
+::
+     sudo apt-get install maven
+     cd mockdriver
+     maven install
 
-sudo apt-get install maven
-cd mockdriver
-maven install
-
-virtualenv ~/.virtualenvs/jaydebeapi-py26 -p /usr/bin/python2.6
-. ~/.virtualenvs/jaydebeapi-py26/bin/activate
-pip install -r dev-requirements.txt -r requirements-python.txt -r test-requirements.txt jip==0.9.3
-envsubst < ci/dot_jip > $VIRTUAL_ENV/.jip
-jip install org.jaydebeapi:mockdriver:1.0-SNAPSHOT
-jip install org.hsqldb:hsqldb:1.8.0.10
-jip install org.xerial:sqlite-jdbc:3.7.2
-export CLASSPATH=$VIRTUAL_ENV/javalib/*
-python setup.py develop
-python test/testsuite.py
+     virtualenv ~/.virtualenvs/jaydebeapi-py26 -p /usr/bin/python2.6
+     . ~/.virtualenvs/jaydebeapi-py26/bin/activate
+     pip install -r dev-requirements.txt -r requirements-python.txt -r test-requirements.txt jip==0.9.3
+     envsubst < ci/dot_jip > $VIRTUAL_ENV/.jip
+     jip install org.jaydebeapi:mockdriver:1.0-SNAPSHOT
+     jip install org.hsqldb:hsqldb:1.8.0.10
+     jip install org.xerial:sqlite-jdbc:3.7.2
+     export CLASSPATH=$VIRTUAL_ENV/javalib/*
+     python setup.py develop
+     python test/testsuite.py
 
 Build a new release
 ===================

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -7,5 +7,9 @@ set -e
 
 if [ -f requirements.txt ]
 then
-    pip install -r requirements.txt
+    if [ $JYTHON ]; then
+        $HOME/jython/bin/pip install -r requirements.txt
+    else
+        pip install -r requirements.txt
+    fi
 fi

--- a/ci/before_install_jython.sh
+++ b/ci/before_install_jython.sh
@@ -7,5 +7,6 @@ java -jar ${JYTHON_JAR} -s -d $HOME/jython
 $HOME/jython/bin/jython -m ensurepip
 
 # Install the latest virtualenv compatible with Jython
-$HOME/jython/bin/pip install virtualenv==1.9.1
-$HOME/jython/bin/virtualenv $HOME/myvirtualenv
+# $HOME/jython/bin/pip install virtualenv==1.9.1
+# virtualenv $HOME/myvirtualenv
+ln -s $VIRTUAL_ENV $HOME/myvirtualenv

--- a/ci/convert_coverage.py
+++ b/ci/convert_coverage.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# coding: utf-8
+import pickle
+import json
+
+inp_file =  open(".coverage", "rb")
+coverage_results = pickle.load(inp_file)
+inp_file.close()
+
+main_results ={"lines": coverage_results['lines']}
+
+out_file = open(".coverage","w")
+out_file.write("!coverage.py: This is a private format, don't read it directly!")
+out_file.write(json.dumps(main_results))
+out_file.close()

--- a/jaydebeapi/__init__.py
+++ b/jaydebeapi/__init__.py
@@ -17,7 +17,7 @@
 # License along with JayDeBeApi.  If not, see
 # <http://www.gnu.org/licenses/>.
 
-__version_info__ = (0, 2, 0)
+__version_info__ = (0, 2, 1)
 __version__ = ".".join(str(i) for i in __version_info__)
 
 import datetime

--- a/jaydebeapi/__init__.py
+++ b/jaydebeapi/__init__.py
@@ -77,12 +77,12 @@ _handle_sql_exception = None
 _dict_to_properties = None
 
 
-def _check_if_args_contain_properties(args):
+def _do_args_contain_properties(args):
     return len(args) == 2 and isinstance(args[1], dict)
 
 
 def _prepair_arguments_for_driver(args):
-   if _check_if_args_contain_properties(args):
+   if _do_args_contain_properties(args):
        args = (args[0], _dict_to_properties(args[1]))
    return args
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ if not sys.platform.lower().startswith('java'):
 setup(
     #basic package data
     name = 'JayDeBeApi',
-    version = '0.2.0',
+    version = '0.2.1',
     author = 'Bastian Bowe',
     author_email = 'bastian.dev@gmail.com',
     license = 'GNU LGPL',

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -240,7 +240,6 @@ class SqlitePyTest(SqliteTestBase, unittest.TestCase):
         """Time type not supported by PySqlite"""
 
 class SqliteXerialTest(SqliteTestBase, unittest.TestCase):
-
     def connect(self):
         #http://bitbucket.org/xerial/sqlite-jdbc
         # sqlite-jdbc-3.7.2.jar
@@ -270,6 +269,19 @@ class HsqldbTest(IntegrationTestBase, unittest.TestCase):
         driver, driver_args = 'org.hsqldb.jdbcDriver', ['jdbc:hsqldb:mem:.',
                                                         'SA', '']
         return jaydebeapi, jaydebeapi.connect(driver, driver_args)
+
+    def setUpSql(self):
+        self.sql_file(os.path.join(_THIS_DIR, 'data', 'create_hsqldb.sql'))
+        self.sql_file(os.path.join(_THIS_DIR, 'data', 'insert.sql'))
+
+class HsqldbDictParamsTest(IntegrationTestBase, unittest.TestCase):
+    def connect(self):
+        # http://hsqldb.org/
+        # hsqldb.jar
+        driver = 'org.hsqldb.jdbcDriver'
+        url = 'jdbc:hsqldb:mem:.'
+        info = {'user':'SA', 'password':''}
+        return jaydebeapi, jaydebeapi.connect(driver, (url, info))
 
     def setUpSql(self):
         self.sql_file(os.path.join(_THIS_DIR, 'data', 'create_hsqldb.sql'))


### PR DESCRIPTION
I've made it for my issue https://github.com/baztian/jaydebeapi/issues/16.
Now I can connect to SQL Server with domain-based authentication. Like this:

``` python
connection = jaydebeapi.connect("net.sourceforge.jtds.jdbc.Driver",
                                  ['jdbc:jtds:sqlserver://server:1433/database', 
                                    {'user':'my.user.name',
                                     'password':'mYpa55w0RD',
                                     'domain':'DOMAINNAME'}
                                  ],
                                 '/path/to/jar/jtds-1.2.5.jar')
```
