### PR TITLE
Dtypes

### DIFF
--- a/jaydebeapi/__init__.py
+++ b/jaydebeapi/__init__.py
@@ -559,22 +559,34 @@ def _to_datetime(rs, col):
     java_val = rs.getTimestamp(col)
     if not java_val:
         return
-    d = datetime.datetime.strptime(str(java_val)[:19], "%Y-%m-%d %H:%M:%S")
-    d = d.replace(microsecond=int(str(java_val.getNanos())[:6]))
-    return str(d)
+    elements = (java_val
+        .toString()
+        .replace('-', ' ')
+        .replace(':', ' ')
+        .replace('.', ' ')
+        .split()
+        )
+    return datetime.datetime(*(int(element) for element in elements))
 
 def _to_time(rs, col):
-    java_val = rs.getTime(col)
+    java_val = rs.getTimestamp(col)
     if not java_val:
         return
-    return str(java_val)
+    elements = (java_val
+        .toString()
+        .split()[1]
+        .replace(':', ' ')
+        .replace('.', ' ')
+        .split()
+        )
+    return datetime.time(*(int(element) for element in elements))
 
 def _to_date(rs, col):
     java_val = rs.getDate(col)
     if not java_val:
         return
-    d = datetime.datetime.strptime(str(java_val)[:10], "%Y-%m-%d")
-    return d.strftime("%Y-%m-%d")
+    elements = java_val.toString().split('-')
+    return datetime.date(*(int(element) for element in elements))
 
 def _to_binary(rs, col):
     java_val = rs.getObject(col)

--- a/jaydebeapi/__init__.py
+++ b/jaydebeapi/__init__.py
@@ -257,7 +257,7 @@ TEXT = DBAPITypeObject('CLOB', 'LONGVARCHAR', 'LONGNVARCHAR', 'NCLOB', 'SQLXML')
 
 BINARY = DBAPITypeObject('BINARY', 'BLOB', 'LONGVARBINARY', 'VARBINARY')
 
-NUMBER = DBAPITypeObject('BOOLEAN', 'BIGINT', 'INTEGER', 'SMALLINT')
+NUMBER = DBAPITypeObject('BOOLEAN', 'BIGINT', 'INTEGER', 'SMALLINT', 'TINYINT')
 
 FLOAT = DBAPITypeObject('FLOAT', 'REAL', 'DOUBLE')
 
@@ -627,11 +627,17 @@ _DEFAULT_CONVERTERS = {
     'TIME': _to_time,
     'DATE': _to_date,
     'BINARY': _to_binary,
+    'BLOB': _to_binary,
+    'LONGVARBINARY': _to_binary,
+    'VARBINARY': _to_binary,
     'DECIMAL': _to_double,
     'NUMERIC': _to_double,
     'DOUBLE': _to_double,
     'FLOAT': _to_double,
+    'REAL': _to_double,
     'INTEGER': _to_int,
     'SMALLINT': _to_int,
+    'BIGINT': _to_int,
+    'TINYINT': _to_int,
     'BOOLEAN': _java_to_py('booleanValue'),
 }


### PR DESCRIPTION
I have included a few more data types to the `_DEFAULT_CONVERTERS` dictionary. All of these were already mapped in `DBAPITypeObject`, except for TINYINT, which is new.

I also altered `_to_datetime`, `_to_date`, and `_to_time` to return objects from the `datetime` module instead of strings. This behavior seems to be more consistent with the DB API 2.0 spec.

I have to admit that I tried following the README_development.rst instructions to run the tests, but I ran into issues at the `jip install` steps that prevented me from doing so. I hope this doesn't cause too much of a problem.