### PR TITLE
Support connection parameters, execute non-prepared statements

### DIFF
--- a/jaydebeapi/__init__.py
+++ b/jaydebeapi/__init__.py
@@ -397,10 +397,6 @@ class Connection(object):
         except:
             _handle_sql_exception()
 
-    def execute(self, sql):
-        stmt = self.jconn.createStatement()
-        return stmt.executeQuery(sql)
-
     def rollback(self):
         try:
             self.jconn.rollback()
@@ -481,15 +477,25 @@ class Cursor(object):
     def execute(self, operation, parameters=None):
         if self._connection._closed:
             raise Error()
-        if not parameters:
-            parameters = ()
+
         self._close_last()
-        self._prep = self._connection.jconn.prepareStatement(operation)
-        self._set_stmt_parms(self._prep, parameters)
-        try:
-            is_rs = self._prep.execute()
-        except:
-            _handle_sql_exception()
+
+        if parameters == None:
+            self._prep = self._connection.jconn.createStatement()
+
+            try:
+                is_rs = self._prep.execute(operation)
+            except:
+                _handle_sql_exception()
+        else:
+            self._prep = self._connection.jconn.prepareStatement(operation)
+            self._set_stmt_parms(self._prep, parameters)
+
+            try:
+                is_rs = self._prep.execute()
+            except:
+                _handle_sql_exception()
+
         if is_rs:
             self._rs = self._prep.getResultSet()
             self._meta = self._rs.getMetaData()

--- a/mockdriver/src/main/java/org/jaydebeapi/mockdriver/MockConnection.java
+++ b/mockdriver/src/main/java/org/jaydebeapi/mockdriver/MockConnection.java
@@ -2,6 +2,7 @@ package org.jaydebeapi.mockdriver;
 
 import java.lang.reflect.Field;
 import java.sql.Connection;
+import java.sql.Statement;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -25,16 +26,22 @@ public abstract class MockConnection implements Connection {
 
     public final void mockExceptionOnExecute(String className, String exceptionMessage) throws SQLException {
         PreparedStatement mockPreparedStatement = Mockito.mock(PreparedStatement.class);
+        Statement mockStatement = Mockito.mock(Statement.class);
         Throwable exception = createException(className, exceptionMessage);
         Mockito.when(mockPreparedStatement.execute()).thenThrow(exception);
+        Mockito.when(mockStatement.execute(Mockito.anyString())).thenThrow(exception);
         Mockito.when(this.prepareStatement(Mockito.anyString())).thenReturn(mockPreparedStatement);
+        Mockito.when(this.createStatement()).thenReturn(mockStatement);
     }
 
     public final void mockType(String sqlTypesName) throws SQLException {
         PreparedStatement mockPreparedStatement = Mockito.mock(PreparedStatement.class);
+        Statement mockStatement = Mockito.mock(Statement.class);
         Mockito.when(mockPreparedStatement.execute()).thenReturn(true);
+        Mockito.when(mockStatement.execute(Mockito.anyString())).thenReturn(true);
         mockResultSet = Mockito.mock(ResultSet.class, "ResultSet(for type " + sqlTypesName + ")");
         Mockito.when(mockPreparedStatement.getResultSet()).thenReturn(mockResultSet);
+        Mockito.when(mockStatement.getResultSet()).thenReturn(mockResultSet);
         Mockito.when(mockResultSet.next()).thenReturn(true);
         ResultSetMetaData mockMetaData = Mockito.mock(ResultSetMetaData.class);
         Mockito.when(mockResultSet.getMetaData()).thenReturn(mockMetaData);
@@ -42,6 +49,7 @@ public abstract class MockConnection implements Connection {
         int sqlTypeCode = extractTypeCodeForName(sqlTypesName);
         Mockito.when(mockMetaData.getColumnType(1)).thenReturn(sqlTypeCode);
         Mockito.when(this.prepareStatement(Mockito.anyString())).thenReturn(mockPreparedStatement);
+        Mockito.when(this.createStatement()).thenReturn(mockStatement);
     }
 
     public final ResultSet verifyResultSet() {

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -213,7 +213,6 @@ class IntegrationTestBase(object):
         try:
             cursor.execute("dummy stmt")
         except jaydebeapi.DatabaseError as e:
-            print str(e)
             self.assertEquals(str(e).split(" ")[0], "java.sql.SQLException:")
         except self.conn.OperationalError as e:
             self.assertEquals("syntax" in str(e), True)

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -207,6 +207,20 @@ class IntegrationTestBase(object):
         cursor.execute("select * from ACCOUNT")
         self.assertEqual(cursor.rowcount, -1)
 
+    def test_sql_exception_on_execute(self):
+        cursor = self.conn.cursor()
+        try:
+            cursor.execute("dummy stmt")
+        except jaydebeapi.DatabaseError as e:
+            self.assertEquals(str(e), "java.sql.SQLException: expected")
+
+    def test_sql_exception_on_prepared_execute(self):
+        cursor = self.conn.cursor()
+        try:
+            cursor.execute("dummy stmt ?", (18,))
+        except jaydebeapi.DatabaseError as e:
+            self.assertEquals(str(e), "java.sql.SQLException: expected")
+
 class SqliteTestBase(IntegrationTestBase):
 
     def setUpSql(self):

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -18,6 +18,7 @@
 # <http://www.gnu.org/licenses/>.
 
 import jaydebeapi
+from jaydebeapi import OperationalError
 
 import os
 import sys
@@ -212,7 +213,10 @@ class IntegrationTestBase(object):
         try:
             cursor.execute("dummy stmt")
         except jaydebeapi.DatabaseError as e:
+            print str(e)
             self.assertEquals(str(e).split(" ")[0], "java.sql.SQLException:")
+        except self.conn.OperationalError as e:
+            self.assertEquals("syntax" in str(e), True)
 
 class SqliteTestBase(IntegrationTestBase):
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -214,13 +214,6 @@ class IntegrationTestBase(object):
         except jaydebeapi.DatabaseError as e:
             self.assertEquals(str(e).split(" ")[0], "java.sql.SQLException:")
 
-    def test_sql_exception_on_prepared_execute(self):
-        cursor = self.conn.cursor()
-        try:
-            cursor.execute("dummy stmt ?", (18,))
-        except jaydebeapi.DatabaseError as e:
-            self.assertEquals(str(e).split(" ")[0], "java.sql.SQLException:")
-
 class SqliteTestBase(IntegrationTestBase):
 
     def setUpSql(self):

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -212,14 +212,14 @@ class IntegrationTestBase(object):
         try:
             cursor.execute("dummy stmt")
         except jaydebeapi.DatabaseError as e:
-            self.assertEquals(str(e), "java.sql.SQLException: expected")
+            self.assertEquals(str(e).split(" ")[0], "java.sql.SQLException:")
 
     def test_sql_exception_on_prepared_execute(self):
         cursor = self.conn.cursor()
         try:
             cursor.execute("dummy stmt ?", (18,))
         except jaydebeapi.DatabaseError as e:
-            self.assertEquals(str(e), "java.sql.SQLException: expected")
+            self.assertEquals(str(e).split(" ")[0], "java.sql.SQLException:")
 
 class SqliteTestBase(IntegrationTestBase):
 

--- a/test/test_mock.py
+++ b/test/test_mock.py
@@ -59,6 +59,15 @@ class MockTest(unittest.TestCase):
         except jaydebeapi.DatabaseError as e:
             self.assertEquals(str(e), "java.sql.SQLException: expected")
 
+    def test_sql_exception_on_parameter_execute(self):
+        self.conn.jconn.mockExceptionOnExecute("java.sql.SQLException", "expected")
+        cursor = self.conn.cursor()
+        try:
+            cursor.execute("dummy stmt", (18,))
+            fail("expected exception")
+        except jaydebeapi.DatabaseError as e:
+            self.assertEquals(str(e), "java.sql.SQLException: expected")
+
     def test_runtime_exception_on_execute(self):
         self.conn.jconn.mockExceptionOnExecute("java.lang.RuntimeException", "expected")
         cursor = self.conn.cursor()


### PR DESCRIPTION
This pull request enables using the AWS Athena JDBC driver, which requires certain properties passed at connection time, and does not support prepared statements.

Code for connection properties is appropriated from @Melraidin. 

It will, by default, execute queries as standard statements, unless properties (including an empty parameter set) are passed into the execute function.