### PR TITLE
allow execution of queries without prepared statements

### DIFF
--- a/jaydebeapi/__init__.py
+++ b/jaydebeapi/__init__.py
@@ -488,18 +488,29 @@ class Cursor(object):
             # print (i, parameters[i], type(parameters[i]))
             prep_stmt.setObject(i + 1, parameters[i])
 
-    def execute(self, operation, parameters=None):
+    def execute(self, operation, parameters=None, use_prepared_statements=True):
         if self._connection._closed:
             raise Error()
         if not parameters:
             parameters = ()
         self._close_last()
-        self._prep = self._connection.jconn.prepareStatement(operation)
-        self._set_stmt_parms(self._prep, parameters)
-        try:
-            is_rs = self._prep.execute()
-        except:
-            _handle_sql_exception()
+
+        if use_prepared_statements:
+            self._prep = self._connection.jconn.prepareStatement(operation)
+            self._set_stmt_parms(self._prep, parameters)
+            
+            try:
+                is_rs = self._prep.execute()
+            except:
+                _handle_sql_exception()
+        else:
+            self._prep = self._connection.jconn.createStatement()
+            
+            try:
+                is_rs = self._prep.execute(operation)
+            except:
+                _handle_sql_exception()
+
         if is_rs:
             self._rs = self._prep.getResultSet()
             self._meta = self._rs.getMetaData()

--- a/mockdriver/src/main/java/org/jaydebeapi/mockdriver/MockConnection.java
+++ b/mockdriver/src/main/java/org/jaydebeapi/mockdriver/MockConnection.java
@@ -2,6 +2,7 @@ package org.jaydebeapi.mockdriver;
 
 import java.lang.reflect.Field;
 import java.sql.Connection;
+import java.sql.Statement;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -25,16 +26,22 @@ public abstract class MockConnection implements Connection {
 
     public final void mockExceptionOnExecute(String className, String exceptionMessage) throws SQLException {
         PreparedStatement mockPreparedStatement = Mockito.mock(PreparedStatement.class);
+        Statement mockStatement = Mockito.mock(Statement.class);
         Throwable exception = createException(className, exceptionMessage);
         Mockito.when(mockPreparedStatement.execute()).thenThrow(exception);
+        Mockito.when(mockStatement.execute(Mockito.anyString())).thenThrow(exception);
         Mockito.when(this.prepareStatement(Mockito.anyString())).thenReturn(mockPreparedStatement);
+        Mockito.when(this.createStatement()).thenReturn(mockStatement);
     }
 
     public final void mockType(String sqlTypesName) throws SQLException {
         PreparedStatement mockPreparedStatement = Mockito.mock(PreparedStatement.class);
+        Statement mockStatement = Mockito.mock(Statement.class);
         Mockito.when(mockPreparedStatement.execute()).thenReturn(true);
+        Mockito.when(mockStatement.execute(Mockito.anyString())).thenReturn(true);
         mockResultSet = Mockito.mock(ResultSet.class, "ResultSet(for type " + sqlTypesName + ")");
         Mockito.when(mockPreparedStatement.getResultSet()).thenReturn(mockResultSet);
+        Mockito.when(mockStatement.getResultSet()).thenReturn(mockResultSet);
         Mockito.when(mockResultSet.next()).thenReturn(true);
         ResultSetMetaData mockMetaData = Mockito.mock(ResultSetMetaData.class);
         Mockito.when(mockResultSet.getMetaData()).thenReturn(mockMetaData);
@@ -42,6 +49,7 @@ public abstract class MockConnection implements Connection {
         int sqlTypeCode = extractTypeCodeForName(sqlTypesName);
         Mockito.when(mockMetaData.getColumnType(1)).thenReturn(sqlTypeCode);
         Mockito.when(this.prepareStatement(Mockito.anyString())).thenReturn(mockPreparedStatement);
+        Mockito.when(this.createStatement()).thenReturn(mockStatement);
     }
 
     public final ResultSet verifyResultSet() {

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -18,6 +18,7 @@
 # <http://www.gnu.org/licenses/>.
 
 import jaydebeapi
+from jaydebeapi import OperationalError
 
 import os
 import sys
@@ -206,6 +207,15 @@ class IntegrationTestBase(object):
         self.assertEqual(cursor.rowcount, 1)
         cursor.execute("select * from ACCOUNT")
         self.assertEqual(cursor.rowcount, -1)
+
+    def test_sql_exception_on_execute(self):
+        cursor = self.conn.cursor()
+        try:
+            cursor.execute("dummy stmt", use_prepared_statements=False)
+        except jaydebeapi.DatabaseError as e:
+            self.assertEquals(str(e).split(" ")[0], "java.sql.SQLException:")
+        except self.conn.OperationalError as e:
+            self.assertEquals("syntax" in str(e), True)
 
 class SqliteTestBase(IntegrationTestBase):
 

--- a/test/test_mock.py
+++ b/test/test_mock.py
@@ -59,6 +59,15 @@ class MockTest(unittest.TestCase):
         except jaydebeapi.DatabaseError as e:
             self.assertEquals(str(e), "java.sql.SQLException: expected")
 
+    def test_sql_exception_on_no_prepared_execute(self):
+        self.conn.jconn.mockExceptionOnExecute("java.sql.SQLException", "expected")
+        cursor = self.conn.cursor()
+        try:
+            cursor.execute("dummy stmt", use_prepared_statements=False)
+            fail("expected exception")
+        except jaydebeapi.DatabaseError as e:
+            self.assertEquals(str(e), "java.sql.SQLException: expected")
+
     def test_runtime_exception_on_execute(self):
         self.conn.jconn.mockExceptionOnExecute("java.lang.RuntimeException", "expected")
         cursor = self.conn.cursor()


### PR DESCRIPTION
Execute queries as prepared statements by default, but allow the option of executing them as standard statements.