### PR TITLE
Dates before 1900

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -159,6 +159,9 @@ Changelog
 =========
 
 - Next version - unreleased
+
+  - Don't fail on dates before 1900 on Python < 3.
+
 - 1.1.0 - 2017-03-19
 
   - Support BIT and TINYINT type mappings (thanks @Mokubyow for

--- a/jaydebeapi/__init__.py
+++ b/jaydebeapi/__init__.py
@@ -595,8 +595,12 @@ def _to_date(rs, col):
     java_val = rs.getDate(col)
     if not java_val:
         return
-    d = datetime.datetime.strptime(str(java_val)[:10], "%Y-%m-%d")
-    return d.strftime("%Y-%m-%d")
+    # The following code requires Python 3.3+ on dates before year 1900.
+    # d = datetime.datetime.strptime(str(java_val)[:10], "%Y-%m-%d")
+    # return d.strftime("%Y-%m-%d")
+    # Workaround / simpler soltution (see
+    # https://github.com/baztian/jaydebeapi/issues/18):
+    return str(java_val)[:10]
 
 def _to_binary(rs, col):
     java_val = rs.getObject(col)

--- a/mockdriver/pom.xml
+++ b/mockdriver/pom.xml
@@ -8,8 +8,8 @@
   <packaging>jar</packaging>
 
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/mockdriver/pom.xml
+++ b/mockdriver/pom.xml
@@ -7,6 +7,11 @@
   <version>1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
   <dependencies>
    <dependency>
       <groupId>org.mockito</groupId>

--- a/mockdriver/src/main/java/org/jaydebeapi/mockdriver/MockConnection.java
+++ b/mockdriver/src/main/java/org/jaydebeapi/mockdriver/MockConnection.java
@@ -1,4 +1,3 @@
-
 package org.jaydebeapi.mockdriver;
 
 import java.lang.reflect.Field;
@@ -9,93 +8,92 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
-import java.time.LocalDate;
-
+import java.util.Calendar;
 import org.mockito.Mockito;
 
 public abstract class MockConnection implements Connection {
 
-    ResultSet mockResultSet;
+  ResultSet mockResultSet;
 
-
-    public final void mockExceptionOnCommit(String className, String exceptionMessage) throws SQLException {
-        Throwable exception = createException(className, exceptionMessage);
-        Mockito.doThrow(exception).when(this).commit();
+  private static Throwable createException(String className, String exceptionMessage) {
+    try {
+      return (Throwable) Class.forName(className).getConstructor(String.class)
+          .newInstance(exceptionMessage);
+    } catch (Exception e) {
+      throw new RuntimeException("Couldn't initialize class " + className + ".", e);
     }
+  }
 
-
-    public final void mockExceptionOnRollback(String className, String exceptionMessage) throws SQLException {
-        Throwable exception = createException(className, exceptionMessage);
-        Mockito.doThrow(exception).when(this).rollback();
+  private static int extractTypeCodeForName(String sqlTypesName) {
+    try {
+      Field field = Types.class.getField(sqlTypesName);
+      return field.getInt(null);
+    } catch (NoSuchFieldException e) {
+      throw new IllegalArgumentException("Type " + sqlTypesName + " not found in Types class.", e);
+    } catch (SecurityException e) {
+      throw new RuntimeException(e);
+    } catch (IllegalArgumentException e) {
+      throw new RuntimeException(e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
     }
+  }
 
+  public final void mockExceptionOnCommit(String className, String exceptionMessage)
+      throws SQLException {
+    Throwable exception = createException(className, exceptionMessage);
+    Mockito.doThrow(exception).when(this).commit();
+  }
 
-    public final void mockExceptionOnExecute(String className, String exceptionMessage) throws SQLException {
-        PreparedStatement mockPreparedStatement = Mockito.mock(PreparedStatement.class);
-        Throwable exception = createException(className, exceptionMessage);
-        Mockito.when(mockPreparedStatement.execute()).thenThrow(exception);
-        Mockito.when(this.prepareStatement(Mockito.anyString())).thenReturn(mockPreparedStatement);
-    }
+  public final void mockExceptionOnRollback(String className, String exceptionMessage)
+      throws SQLException {
+    Throwable exception = createException(className, exceptionMessage);
+    Mockito.doThrow(exception).when(this).rollback();
+  }
 
+  public final void mockExceptionOnExecute(String className, String exceptionMessage)
+      throws SQLException {
+    PreparedStatement mockPreparedStatement = Mockito.mock(PreparedStatement.class);
+    Throwable exception = createException(className, exceptionMessage);
+    Mockito.when(mockPreparedStatement.execute()).thenThrow(exception);
+    Mockito.when(this.prepareStatement(Mockito.anyString())).thenReturn(mockPreparedStatement);
+  }
 
-    public final void mockDateResult(int year, int month, int day) throws SQLException {
-        PreparedStatement mockPreparedStatement = Mockito.mock(PreparedStatement.class);
-        Mockito.when(mockPreparedStatement.execute()).thenReturn(true);
-        mockResultSet = Mockito.mock(ResultSet.class, "ResultSet(for date)");
-        Mockito.when(mockPreparedStatement.getResultSet()).thenReturn(mockResultSet);
-        Mockito.when(mockResultSet.next()).thenReturn(true);
-        ResultSetMetaData mockMetaData = Mockito.mock(ResultSetMetaData.class);
-        Mockito.when(mockResultSet.getMetaData()).thenReturn(mockMetaData);
-        Mockito.when(mockMetaData.getColumnCount()).thenReturn(1);
-        Date ancientDate = Date.valueOf(LocalDate.of(year, month, day));
-        Mockito.when(mockResultSet.getDate(1)).thenReturn(ancientDate);
-        Mockito.when(mockMetaData.getColumnType(1)).thenReturn(Types.DATE);
-        Mockito.when(this.prepareStatement(Mockito.anyString())).thenReturn(mockPreparedStatement);
-    }
+  public final void mockDateResult(int year, int month, int day) throws SQLException {
+    PreparedStatement mockPreparedStatement = Mockito.mock(PreparedStatement.class);
+    Mockito.when(mockPreparedStatement.execute()).thenReturn(true);
+    mockResultSet = Mockito.mock(ResultSet.class, "ResultSet(for date)");
+    Mockito.when(mockPreparedStatement.getResultSet()).thenReturn(mockResultSet);
+    Mockito.when(mockResultSet.next()).thenReturn(true);
+    ResultSetMetaData mockMetaData = Mockito.mock(ResultSetMetaData.class);
+    Mockito.when(mockResultSet.getMetaData()).thenReturn(mockMetaData);
+    Mockito.when(mockMetaData.getColumnCount()).thenReturn(1);
+    Calendar cal = Calendar.getInstance();
+    cal.clear();
+    cal.set(Calendar.YEAR, year);
+    cal.set(Calendar.MONTH, month - 1);
+    cal.set(Calendar.DAY_OF_MONTH, day);
+    Date ancientDate = new Date(cal.getTime().getTime());
+    Mockito.when(mockResultSet.getDate(1)).thenReturn(ancientDate);
+    Mockito.when(mockMetaData.getColumnType(1)).thenReturn(Types.DATE);
+    Mockito.when(this.prepareStatement(Mockito.anyString())).thenReturn(mockPreparedStatement);
+  }
 
+  public final void mockType(String sqlTypesName) throws SQLException {
+    PreparedStatement mockPreparedStatement = Mockito.mock(PreparedStatement.class);
+    Mockito.when(mockPreparedStatement.execute()).thenReturn(true);
+    mockResultSet = Mockito.mock(ResultSet.class, "ResultSet(for type " + sqlTypesName + ")");
+    Mockito.when(mockPreparedStatement.getResultSet()).thenReturn(mockResultSet);
+    Mockito.when(mockResultSet.next()).thenReturn(true);
+    ResultSetMetaData mockMetaData = Mockito.mock(ResultSetMetaData.class);
+    Mockito.when(mockResultSet.getMetaData()).thenReturn(mockMetaData);
+    Mockito.when(mockMetaData.getColumnCount()).thenReturn(1);
+    int sqlTypeCode = extractTypeCodeForName(sqlTypesName);
+    Mockito.when(mockMetaData.getColumnType(1)).thenReturn(sqlTypeCode);
+    Mockito.when(this.prepareStatement(Mockito.anyString())).thenReturn(mockPreparedStatement);
+  }
 
-    public final void mockType(String sqlTypesName) throws SQLException {
-        PreparedStatement mockPreparedStatement = Mockito.mock(PreparedStatement.class);
-        Mockito.when(mockPreparedStatement.execute()).thenReturn(true);
-        mockResultSet = Mockito.mock(ResultSet.class, "ResultSet(for type " + sqlTypesName + ")");
-        Mockito.when(mockPreparedStatement.getResultSet()).thenReturn(mockResultSet);
-        Mockito.when(mockResultSet.next()).thenReturn(true);
-        ResultSetMetaData mockMetaData = Mockito.mock(ResultSetMetaData.class);
-        Mockito.when(mockResultSet.getMetaData()).thenReturn(mockMetaData);
-        Mockito.when(mockMetaData.getColumnCount()).thenReturn(1);
-        int sqlTypeCode = extractTypeCodeForName(sqlTypesName);
-        Mockito.when(mockMetaData.getColumnType(1)).thenReturn(sqlTypeCode);
-        Mockito.when(this.prepareStatement(Mockito.anyString())).thenReturn(mockPreparedStatement);
-    }
-
-
-    public final ResultSet verifyResultSet() {
-        return Mockito.verify(mockResultSet);
-    }
-
-
-    private static Throwable createException(String className, String exceptionMessage) {
-        try {
-            return (Throwable) Class.forName(className).getConstructor(String.class).newInstance(exceptionMessage);
-        } catch (Exception e) {
-            throw new RuntimeException("Couldn't initialize class " + className + ".", e);
-        }
-    }
-
-
-    private static int extractTypeCodeForName(String sqlTypesName) {
-        try {
-            Field field = Types.class.getField(sqlTypesName);
-            return field.getInt(null);
-        } catch (NoSuchFieldException e) {
-            throw new IllegalArgumentException("Type " + sqlTypesName + " not found in Types class.", e);
-        } catch (SecurityException e) {
-            throw new RuntimeException(e);
-        } catch (IllegalArgumentException e) {
-            throw new RuntimeException(e);
-        } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
+  public final ResultSet verifyResultSet() {
+    return Mockito.verify(mockResultSet);
+  }
 }

--- a/test/test_mock.py
+++ b/test/test_mock.py
@@ -50,6 +50,13 @@ class MockTest(unittest.TestCase):
                                                                  'getObject'))
                     verify_get(1)
 
+    def test_ancient_date_mapped(self):
+        self.conn.jconn.mockDateResult(1899, 12, 31)
+        cursor = self.conn.cursor()
+        cursor.execute("dummy stmt")
+        result = cursor.fetchone()
+        self.assertEquals(result[0], "1899-12-31")
+
     def test_sql_exception_on_execute(self):
         self.conn.jconn.mockExceptionOnExecute("java.sql.SQLException", "expected")
         cursor = self.conn.cursor()
@@ -58,6 +65,7 @@ class MockTest(unittest.TestCase):
             fail("expected exception")
         except jaydebeapi.DatabaseError as e:
             self.assertEquals(str(e), "java.sql.SQLException: expected")
+
 
     def test_runtime_exception_on_execute(self):
         self.conn.jconn.mockExceptionOnExecute("java.lang.RuntimeException", "expected")

--- a/test/test_mock.py
+++ b/test/test_mock.py
@@ -66,7 +66,6 @@ class MockTest(unittest.TestCase):
         except jaydebeapi.DatabaseError as e:
             self.assertEquals(str(e), "java.sql.SQLException: expected")
 
-
     def test_runtime_exception_on_execute(self):
         self.conn.jconn.mockExceptionOnExecute("java.lang.RuntimeException", "expected")
         cursor = self.conn.cursor()


### PR DESCRIPTION
Allow to read Dates before 1900. Currently this doesn't work for Python < 3.3.
Fixes #18.
- [x] write unit test
- [x] implement fix
- [x] test against Oracle
- [ ] improve mock driver design (less code duplication or more flexible java method)