### PR TITLE
Use the more explicitly typed setObject method.

### DIFF
--- a/jaydebeapi/__init__.py
+++ b/jaydebeapi/__init__.py
@@ -487,7 +487,8 @@ class Cursor(object):
     def _set_stmt_parms(self, prep_stmt, parameters):
         for i in range(len(parameters)):
             # print (i, parameters[i], type(parameters[i]))
-            prep_stmt.setObject(i + 1, parameters[i])
+            ptype = prep_stmt.getParameterMetaData().getParameterType(i + 1)
+            prep_stmt.setObject(i + 1, parameters[i], ptype)
 
     def execute(self, operation, parameters=None):
         if self._connection._closed:


### PR DESCRIPTION
Fixes https://github.com/baztian/jaydebeapi/issues/57 by using the setobject method containing three arguments.