### PR TITLE
Change required for JPype 0.7.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.0
+current_version = 1.1.1
 commit = True
 tag = True
 

--- a/README.rst
+++ b/README.rst
@@ -159,6 +159,7 @@ Changelog
 =========
 
 - Next version - unreleased
+- 1.1.1 - 2017-03-21
 
   - Don't fail on dates before 1900 on Python < 3.
 

--- a/README_development.rst
+++ b/README_development.rst
@@ -69,4 +69,4 @@ Build a new release
 
 9. Send new version and tags to github origin. ::
 
-     $ git push origin master --tags
+     $ git push origin master --follow-tags

--- a/jaydebeapi/__init__.py
+++ b/jaydebeapi/__init__.py
@@ -17,7 +17,7 @@
 # License along with JayDeBeApi.  If not, see
 # <http://www.gnu.org/licenses/>.
 
-__version_info__ = (1, 1, 0)
+__version_info__ = (1, 1, 1)
 __version__ = ".".join(str(i) for i in __version_info__)
 
 import datetime

--- a/jaydebeapi/__init__.py
+++ b/jaydebeapi/__init__.py
@@ -173,7 +173,10 @@ def _jdbc_connect_jpype(jclassname, url, driver_args, jars, libs):
         # jvm_path = ('/usr/lib/jvm/java-6-openjdk'
         #             '/jre/lib/i386/client/libjvm.so')
         jvm_path = jpype.getDefaultJVMPath()
-        jpype.startJVM(jvm_path, *args)
+        if jpype.__version__.startswith("0.6"):
+            jpype.startJVM(jvm_path, *args)
+        else:
+            jpype.startJVM(jvm_path, *args, ignoreUnrecognized=True, convertStrings=True)
     if not jpype.isThreadAttachedToJVM():
         jpype.attachThreadToJVM()
     if _jdbc_name_to_const is None:

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ if not sys.platform.lower().startswith('java'):
 setup(
     #basic package data
     name = 'JayDeBeApi',
-    version = '1.1.0',
+    version = '1.1.1',
     author = 'Bastian Bowe',
     author_email = 'bastian.dev@gmail.com',
     license = 'GNU LGPL',


### PR DESCRIPTION
This deals with the startup.  There are two additional differences.  

```
def _handle_sql_exception_jpype():
    import jpype
    SQLException = jpype.java.sql.SQLException
    exc_info = sys.exc_info()
    if issubclass(exc_info[1].__javaclass__, SQLException):
        exc_type = DatabaseError
    else:
        exc_type = InterfaceError
    reraise(exc_type, exc_info[1], exc_info[2])
```

Exceptions in 0.7 now catch the exception type directly rather than as part of the arguments to the exception.
