### PR TITLE
Add fix for JDBC issue by reloading classpath when attaching JVM to thread

### DIFF
--- a/jaydebeapi/__init__.py
+++ b/jaydebeapi/__init__.py
@@ -192,6 +192,7 @@ def _jdbc_connect_jpype(jclassname, url, driver_args, jars, libs):
                            convertStrings=True)
     if not jpype.isThreadAttachedToJVM():
         jpype.attachThreadToJVM()
+        jpype.java.lang.Thread.currentThread().setContextClassLoader(jpype.java.lang.ClassLoader.getSystemClassLoader())
     if _jdbc_name_to_const is None:
         types = jpype.java.sql.Types
         types_map = {}


### PR DESCRIPTION
I think you'll see that a large number of people have run into similar issues to this: https://github.com/jpype-project/jpype/issues/290 when using jpype. I think that this can be fixed by adding the below call to set the class loader. When added to my own code, this fixed my issues with being unable to load a JAR into the classpath.

[This link](https://jpype.readthedocs.io/en/stable/userguide.html#java-sql-drivermanager-getconnection) from jpype seems to mention that this is a known issue when calling the [`java.sql.DriverManager.getConnection` function](https://github.com/baztian/jaydebeapi/blob/master/jaydebeapi/__init__.py#L219). Please let me know if you have any questions. I hope this is helpful on your end.