### PR TITLE
async connection creation fix

### DIFF
--- a/jaydebeapi/__init__.py
+++ b/jaydebeapi/__init__.py
@@ -194,7 +194,7 @@ def _jdbc_connect_jpype(jclassname, url, driver_args, jars, libs):
                 pass
         if old_jpype:
             jpype.startJVM(jvm_path, *args)
-        else:
+        elif not jpype.isJVMStarted():
             jpype.startJVM(jvm_path, *args, ignoreUnrecognized=True,
                            convertStrings=True)
     if not jpype.isThreadAttachedToJVM():


### PR DESCRIPTION
added check for isJVMStarted to avoid OSError: JVM is already started when creating multiple connections asynchronously.