### PR TITLE
Use raw string for jpype version regex

### DIFF
--- a/jaydebeapi/__init__.py
+++ b/jaydebeapi/__init__.py
@@ -185,7 +185,7 @@ def _jdbc_connect_jpype(jclassname, url, driver_args, jars, libs):
         global old_jpype
         if hasattr(jpype, '__version__'):
             try:
-                ver_match = re.match('\d+\.\d+', jpype.__version__)
+                ver_match = re.match(r'\d+\.\d+', jpype.__version__)
                 if ver_match:
                     jpype_ver = float(ver_match.group(0))
                     if jpype_ver < 0.7:


### PR DESCRIPTION
In a non-raw string, regex escapes and character classes must themselves be backslash-escaped. Previously this string was equivalent to 'd+.d+', which was not the intended regex.