### PR TITLE
Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/test/test_mock.py
+++ b/test/test_mock.py
@@ -55,28 +55,28 @@ class MockTest(unittest.TestCase):
         with self.conn.cursor() as cursor:
             cursor.execute("dummy stmt")
             result = cursor.fetchone()
-        self.assertEquals(result[0], "1899-12-31")
+        self.assertEqual(result[0], "1899-12-31")
 
     def test_decimal_scale_zero(self):
         self.conn.jconn.mockBigDecimalResult(12345, 0)
         with self.conn.cursor() as cursor:
             cursor.execute("dummy stmt")
             result = cursor.fetchone()
-        self.assertEquals(str(result[0]), "12345")
+        self.assertEqual(str(result[0]), "12345")
 
     def test_decimal_places(self):
         self.conn.jconn.mockBigDecimalResult(12345, 1)
         with self.conn.cursor() as cursor:
             cursor.execute("dummy stmt")
             result = cursor.fetchone()
-        self.assertEquals(str(result[0]), "1234.5")
+        self.assertEqual(str(result[0]), "1234.5")
 
     def test_double_decimal(self):
         self.conn.jconn.mockDoubleDecimalResult(1234.5)
         with self.conn.cursor() as cursor:
             cursor.execute("dummy stmt")
             result = cursor.fetchone()
-        self.assertEquals(str(result[0]), "1234.5")
+        self.assertEqual(str(result[0]), "1234.5")
 
     def test_sql_exception_on_execute(self):
         self.conn.jconn.mockExceptionOnExecute("java.sql.SQLException", "expected")
@@ -85,7 +85,7 @@ class MockTest(unittest.TestCase):
                 cursor.execute("dummy stmt")
                 self.fail("expected exception")
             except jaydebeapi.DatabaseError as e:
-                self.assertEquals(str(e), "java.sql.SQLException: expected")
+                self.assertEqual(str(e), "java.sql.SQLException: expected")
 
     def test_runtime_exception_on_execute(self):
         self.conn.jconn.mockExceptionOnExecute("java.lang.RuntimeException", "expected")
@@ -94,7 +94,7 @@ class MockTest(unittest.TestCase):
                 cursor.execute("dummy stmt")
                 self.fail("expected exception")
             except jaydebeapi.InterfaceError as e:
-                self.assertEquals(str(e), "java.lang.RuntimeException: expected")
+                self.assertEqual(str(e), "java.lang.RuntimeException: expected")
 
     def test_sql_exception_on_commit(self):
         self.conn.jconn.mockExceptionOnCommit("java.sql.SQLException", "expected")
@@ -102,7 +102,7 @@ class MockTest(unittest.TestCase):
             self.conn.commit()
             self.fail("expected exception")
         except jaydebeapi.DatabaseError as e:
-            self.assertEquals(str(e), "java.sql.SQLException: expected")
+            self.assertEqual(str(e), "java.sql.SQLException: expected")
 
     def test_runtime_exception_on_commit(self):
         self.conn.jconn.mockExceptionOnCommit("java.lang.RuntimeException", "expected")
@@ -110,7 +110,7 @@ class MockTest(unittest.TestCase):
             self.conn.commit()
             self.fail("expected exception")
         except jaydebeapi.InterfaceError as e:
-            self.assertEquals(str(e), "java.lang.RuntimeException: expected")
+            self.assertEqual(str(e), "java.lang.RuntimeException: expected")
 
     def test_sql_exception_on_rollback(self):
         self.conn.jconn.mockExceptionOnRollback("java.sql.SQLException", "expected")
@@ -118,7 +118,7 @@ class MockTest(unittest.TestCase):
             self.conn.rollback()
             self.fail("expected exception")
         except jaydebeapi.DatabaseError as e:
-            self.assertEquals(str(e), "java.sql.SQLException: expected")
+            self.assertEqual(str(e), "java.sql.SQLException: expected")
 
     def test_runtime_exception_on_rollback(self):
         self.conn.jconn.mockExceptionOnRollback("java.lang.RuntimeException", "expected")
@@ -126,7 +126,7 @@ class MockTest(unittest.TestCase):
             self.conn.rollback()
             self.fail("expected exception")
         except jaydebeapi.InterfaceError as e:
-            self.assertEquals(str(e), "java.lang.RuntimeException: expected")
+            self.assertEqual(str(e), "java.lang.RuntimeException: expected")
 
     def test_cursor_with_statement(self):
         self.conn.jconn.mockType("INTEGER")


### PR DESCRIPTION
The deprecated aliases were removed in Python 3.11 in python/cpython#28268 .