### PR TITLE
Update for JPype deprecation and raw prepend for regex string

### DIFF
--- a/jaydebeapi/__init__.py
+++ b/jaydebeapi/__init__.py
@@ -185,7 +185,7 @@ def _jdbc_connect_jpype(jclassname, url, driver_args, jars, libs):
         global old_jpype
         if hasattr(jpype, '__version__'):
             try:
-                ver_match = re.match('\d+\.\d+', jpype.__version__)
+                ver_match = re.match(r'\d+\.\d+', jpype.__version__)
                 if ver_match:
                     jpype_ver = float(ver_match.group(0))
                     if jpype_ver < 0.7:
@@ -197,8 +197,8 @@ def _jdbc_connect_jpype(jclassname, url, driver_args, jars, libs):
         else:
             jpype.startJVM(jvm_path, *args, ignoreUnrecognized=True,
                            convertStrings=True)
-    if not jpype.isThreadAttachedToJVM():
-        jpype.attachThreadToJVM()
+    if not jpype.java.lang.Thread.isAttached():
+        jpype.java.lang.Thread.attach()
         jpype.java.lang.Thread.currentThread().setContextClassLoader(jpype.java.lang.ClassLoader.getSystemClassLoader())
     if _jdbc_name_to_const is None:
         types = jpype.java.sql.Types


### PR DESCRIPTION
## Overview
These are two small deprecation warning fixes I implemented in a local version that I wanted to share back to you all.

## Before
<img width="810" alt="Screen Shot 2021-11-20 at 12 34 57 PM" src="https://user-images.githubusercontent.com/10490006/142735931-51198a32-7bf5-4346-967e-33885eca37a4.png">
<img width="1284" alt="Screen Shot 2021-11-20 at 12 35 10 PM" src="https://user-images.githubusercontent.com/10490006/142735936-2afd7305-cf95-4c53-87c1-98ab44d3f124.png">

## After
No deprecation warnings and still connecting to databases using jaydebeapi.

