### PR TITLE
Column labels to fix skipping query return aliases 

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.3
+current_version = 1.2.4
 commit = True
 tag = True
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.8]
+        python-version: [2.7, 3.5, 3.6, 3.8, 3.9, 3.10]
         plattform: ["Python"]
         include:
           - python-version: 3.8

--- a/README.rst
+++ b/README.rst
@@ -170,6 +170,10 @@ Changelog
 =========
 
 - Next version - unreleased
+- 1.2.4 - 2022-05-26
+  - Fix returning the column label instead of the name, which accounts for
+    column aliasing in sql queries
+
 - 1.2.3 - 2020-06-12
 
   - Make pip install for Python 2 work by changing JPype1 requirement to older

--- a/jaydebeapi/__init__.py
+++ b/jaydebeapi/__init__.py
@@ -17,7 +17,7 @@
 # License along with JayDeBeApi.  If not, see
 # <http://www.gnu.org/licenses/>.
 
-__version_info__ = (1, 2, 3)
+__version_info__ = (1, 2, 4)
 __version__ = ".".join(str(i) for i in __version_info__)
 
 import datetime

--- a/jaydebeapi/__init__.py
+++ b/jaydebeapi/__init__.py
@@ -488,7 +488,7 @@ class Cursor(object):
                     dbapi_type = None
                 else:
                     dbapi_type = DBAPITypeObject._map_jdbc_type_to_dbapi(jdbc_type)
-                col_desc = ( m.getColumnName(col),
+                col_desc = ( m.getColumnLabel(col),
                              dbapi_type,
                              size,
                              size,

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ install_requires = [ 'JPype1 ; python_version > "2.7" and platform_python_implem
 setup(
     #basic package data
     name = 'JayDeBeApi',
-    version = '1.2.3',
+    version = '1.2.4',
     author = 'Bastian Bowe',
     author_email = 'bastian.dev@gmail.com',
     license = 'GNU LGPL',

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -84,7 +84,7 @@ class IntegrationTestBase(object):
             stmt = "select ACCOUNT_ID as `a_id` from ACCOUNT"
             cursor.execute(stmt)
             field_names = cursor.description
-            self.assertEqual(field_names[0], 'a_id')
+            self.assertEqual(field_names[0][0], 'a_id')
 
     def test_execute_and_fetch(self):
         with self.conn.cursor() as cursor:

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -79,6 +79,13 @@ class IntegrationTestBase(object):
             result = cursor.fetchall()
         self.assertEqual(result, [])
 
+    def test_execute_and_fetch_alias(self):
+        with self.conn.cursor() as cursor:
+            stmt = "select ACCOUNT_ID as `a_id` from ACCOUNT"
+            cursor.execute(stmt)
+            field_names = cursor.description
+            self.assertEqual(field_names[0], 'a_id')
+
     def test_execute_and_fetch(self):
         with self.conn.cursor() as cursor:
             cursor.execute("select ACCOUNT_ID, ACCOUNT_NO, BALANCE, BLOCKING " \


### PR DESCRIPTION
Hi @baztian I have a fix for you, although your test setup seems seriously broken right now and I didn't look forward to fixing that.
So here it is:
- a five-char fix in dunder init, taken from https://sourceforge.net/p/ucanaccess/git-code/ci/master/tree/src/main/java/net/ucanaccess/console/Main.java#l510
- adds a regression test to validate column aliasing in query
- bump the version