### PR TITLE
Clarify license in setup.py metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     classifiers = [
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)',
+        'License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)',
         'Programming Language :: Java',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',


### PR DESCRIPTION
"GNU Library or Lesser General Public License" implies LGPL-2.0 or LGPL-2.1, neither of which are applicable.

As the header comment in setup.py states:
> JayDeBeApi is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.